### PR TITLE
tailwindcss-radix-colors の更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "swagger-ui-react": "^5.1.0",
     "tailwind-merge": "^1.13.2",
     "tailwindcss-animate": "^1.0.6",
-    "tailwindcss-radix-colors": "github:mrcaidev/tailwindcss-radix-colors#8ab16b9d6d6f3d75a7d1cd51b75830d6999c2c88",
+    "tailwindcss-radix-colors": "^0.5.0",
     "trpc-openapi": "^1.2.0",
     "undici": "^5.22.1",
     "zod": "^3.21.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ dependencies:
     specifier: ^1.0.6
     version: 1.0.6(tailwindcss@3.3.2)
   tailwindcss-radix-colors:
-    specifier: github:mrcaidev/tailwindcss-radix-colors#8ab16b9d6d6f3d75a7d1cd51b75830d6999c2c88
-    version: github.com/mrcaidev/tailwindcss-radix-colors/3b72b8c1e8e9be345ec98df7b532d41bed7279a0(tailwindcss@3.3.2)
+    specifier: ^0.5.0
+    version: 0.5.0(tailwindcss@3.3.2)
   trpc-openapi:
     specifier: ^1.2.0
     version: 1.2.0(@trpc/server@10.31.0)(zod@3.21.4)
@@ -6064,6 +6064,15 @@ packages:
       tailwindcss: 3.3.2(ts-node@10.9.1)
     dev: false
 
+  /tailwindcss-radix-colors@0.5.0(tailwindcss@3.3.2):
+    resolution: {integrity: sha512-5v0IndMwt//8a0ZHPuBCIUKyRFUGuLHLNJ75f/puvrpBw9uiZapU9Yegwv7B22s0cilDl64yOl1bHQqvDbHuqw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0'
+    dependencies:
+      '@radix-ui/colors': 0.1.9
+      tailwindcss: 3.3.2(ts-node@10.9.1)
+    dev: false
+
   /tailwindcss@3.3.2(ts-node@10.9.1):
     resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
     engines: {node: '>=14.0.0'}
@@ -6696,16 +6705,4 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
-    dev: false
-
-  github.com/mrcaidev/tailwindcss-radix-colors/3b72b8c1e8e9be345ec98df7b532d41bed7279a0(tailwindcss@3.3.2):
-    resolution: {tarball: https://codeload.github.com/mrcaidev/tailwindcss-radix-colors/tar.gz/3b72b8c1e8e9be345ec98df7b532d41bed7279a0}
-    id: github.com/mrcaidev/tailwindcss-radix-colors/3b72b8c1e8e9be345ec98df7b532d41bed7279a0
-    name: tailwindcss-radix-colors
-    version: 0.3.1
-    peerDependencies:
-      tailwindcss: '>=3.0.0'
-    dependencies:
-      '@radix-ui/colors': 0.1.9
-      tailwindcss: 3.3.2(ts-node@10.9.1)
     dev: false

--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -32,6 +32,7 @@ export default function Page() {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+      <div className="bg-whitea-13">この部分の背景色は白です。</div>
     </main>
   );
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 const config = {
+  theme: {
+    extend: {
+      colors: {
+        "whitea-13": "#ffffff",
+      },
+    },
+  },
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   plugins: [require("tailwindcss-animate"), require("tailwindcss-radix-colors")],
 };


### PR DESCRIPTION
## 概要

- tailwindcss-radix-colors を最新化した
  - #21 の妥協点を解決するため
  - 最新版は npm で公開されているため、最早 commit ID を指定する必要は無くなった
- `tailwind.config.mjs`で Radix Colors にはない白色を追加
  - `whitea-13`という名前で白色（透過なし）を追加
    - `white`という名前にしたかったが、競合のためか追加しても反映されなかったため

## 動作確認

- http://localhost:3000/list で`bg-whitea-13`があたっている箇所の背景が白色になっていること
