### PR TITLE
ChefDetailComponent作成

### DIFF
--- a/src/app/chef/[id]/layout.tsx
+++ b/src/app/chef/[id]/layout.tsx
@@ -1,0 +1,10 @@
+import { ChefDetail } from "@/components/chef-detail/chef-detail";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <main>
+      <ChefDetail />
+      {children}
+    </main>
+  );
+}

--- a/src/app/chef/[id]/page.tsx
+++ b/src/app/chef/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page({ params }: { params: { id: string } }) {
+  return;
+}

--- a/src/components/chef-detail/back-button.tsx
+++ b/src/components/chef-detail/back-button.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { HiArrowLeft } from "react-icons/hi2";
+
+export const BackButton = () => {
+  const router = useRouter();
+
+  const handleGoBack = () => {
+    // 遷移前のページが存在する場合:戻る/存在しない場合:トップページに遷移
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/");
+    }
+  };
+
+  return (
+    <button className="" onClick={() => handleGoBack()}>
+      <HiArrowLeft size={24} />
+    </button>
+  );
+};

--- a/src/components/chef-detail/chef-detail.tsx
+++ b/src/components/chef-detail/chef-detail.tsx
@@ -46,11 +46,16 @@ export const ChefDetail = () => {
         </Avatar>
       </div>
       <p className="pb-2 text-mauve-12">{chef_detail_info.detail}</p>
-      <div className="flex pb-4 text-sm text-mauve-11">
-        <span className="mr-1 font-bold">{chef_detail_info.recipe_count}</span>
-        <span className="mr-2">レシピ</span>
-        <span className="mr-1 font-bold">{chef_detail_info.follower_count}</span>
-        <span>フォロワー</span>
+      <div className="flex items-center gap-x-4 pb-4 text-sm text-mauve-11">
+        {[
+          [chef_detail_info.recipe_count, "レシピ"],
+          [chef_detail_info.follower_count, "フォロワー"],
+        ].map(([count, unit], index) => (
+          <div key={index} className="flex items-center gap-x-1">
+            <span className="font-bold">{count}</span>
+            <span>{unit}</span>
+          </div>
+        ))}
       </div>
       {/* フォローするボタンはコンポーネント化予定 */}
       <ChefFollowButton />

--- a/src/components/chef-detail/chef-detail.tsx
+++ b/src/components/chef-detail/chef-detail.tsx
@@ -1,0 +1,59 @@
+import { HiOutlineEllipsisHorizontalCircle } from "react-icons/hi2";
+import { IoLogoInstagram } from "react-icons/io";
+import { SlSocialYoutube } from "react-icons/sl";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/avatar/avatar";
+import { BackButton } from "@/components/chef-detail/back-button";
+import { ChefFollowButton } from "@/features/users";
+
+export const ChefDetail = () => {
+  // デザイン用の仮の値
+  const chef_detail_info = {
+    name: "山々駄々シェフ",
+    user_id: "yamada19990101",
+    image_path: "/images/chef_04.jpeg",
+    detail:
+      "吾輩は猫である。名前はまだ無い。どこで生れたかとんと見当がつかぬ。何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。",
+    recipe_count: 2345,
+    follower_count: 1234,
+  };
+
+  return (
+    <div className="p-4">
+      <div className="mb-2 flex items-start justify-between">
+        <BackButton />
+        {/* リンクボタンはコンポーネント化予定 */}
+        <div className={"flex items-center gap-x-3 text-2xl"}>
+          <button type={"button"}>
+            <SlSocialYoutube />
+          </button>
+          <button type={"button"}>
+            <IoLogoInstagram />
+          </button>
+          <button type={"button"}>
+            <HiOutlineEllipsisHorizontalCircle />
+          </button>
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-1 py-4">
+          <h1 className="text-xl font-bold text-mauve-12">{chef_detail_info.name}</h1>
+          <p className="text-sm text-mauve-12">{chef_detail_info.user_id}</p>
+        </div>
+        <Avatar>
+          <AvatarImage src={chef_detail_info.image_path} />
+          <AvatarFallback>シェフ</AvatarFallback>
+        </Avatar>
+      </div>
+      <p className="pb-2 text-mauve-12">{chef_detail_info.detail}</p>
+      <div className="flex pb-4 text-sm text-mauve-11">
+        <span className="mr-1 font-bold">{chef_detail_info.recipe_count}</span>
+        <span className="mr-2">レシピ</span>
+        <span className="mr-1 font-bold">{chef_detail_info.follower_count}</span>
+        <span>フォロワー</span>
+      </div>
+      {/* フォローするボタンはコンポーネント化予定 */}
+      <ChefFollowButton />
+    </div>
+  );
+};

--- a/src/features/users/components/chef-follow-button.tsx
+++ b/src/features/users/components/chef-follow-button.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useState } from "react";
+
+export const ChefFollowButton = () => {
+  const [isFollow, setFollow] = useState(false);
+  const toggleFollow = () => setFollow(!isFollow);
+  const followButtonToggleStyle = isFollow
+    ? "bg-tomato-solid border-transparent"
+    : "border-tomato-normal text-tomato-dim";
+
+  return (
+    <button onClick={toggleFollow} className={`w-full rounded-md  border px-3 py-1 text-sm ${followButtonToggleStyle}`}>
+      {isFollow ? "フォローする" : "フォロー中"}
+    </button>
+  );
+};

--- a/src/features/users/components/component-a/component-a.tsx
+++ b/src/features/users/components/component-a/component-a.tsx
@@ -1,9 +1,0 @@
-//import {} from ~
-//import { XXX } from '../../types';
-
-//基本的にAPIは使わない
-//appの中のコンポーネントでたたいたデータをこのコンポーネントに渡す
-
-export const ComponentA = () => {
-  return <div>ComponentA</div>;
-}

--- a/src/features/users/components/component-a/index.ts
+++ b/src/features/users/components/component-a/index.ts
@@ -1,1 +1,0 @@
-export * from './component-a;

--- a/src/features/users/index.ts
+++ b/src/features/users/index.ts
@@ -1,11 +1,7 @@
 // components:
-export * from './components/component-a;
-//export * from './components/component-b';
-//export * from './components/component-c';
-//export * from './components/component-d';
+export * from "./components/chef-follow-button";
 
 // api:
-export * from './api/api-a';
 // export * from './api/api-b';
 
 // types:


### PR DESCRIPTION
## issue
- https://github.com/qin-team-recipe/08-recipe-app/issues/47

## URL
- http://localhost:3000/chef/1

## 対応内容・対応妥協点

### 対応内容
- ChefDetailComponent作成

### 対応妥協点
- issueの補足にある通り、リンクボタン・フォローするボタンは共通化予定なので、とりあえず仮作成（レシピ詳細のコピペなのでレビューの必要なし）。
- プロフィール編集ボタンも、フォローするボタン共通化を適応させる時に作ろうかと思います。
- 文字の長さ制限とかは何も付けてないです。カラムの文字数との兼ね合いになると思うので、DBと接続して取得する段階で考えようかと思います。

## UI
<img width="671" alt="image" src="https://github.com/qin-team-recipe/08-recipe-app/assets/73679908/a0f4860b-a20a-4d42-83b5-901a887814ff">


## レビュー観点
- 正常に表示できているか
- コンポーネントの使い勝手が悪くないか
- 戻るボタンを押した時に、historyがある場合は前のページに戻り、ない場合はトップページに戻るのかどうか