### PR TITLE
VerticalRecipeListコンポーネント作成

### DIFF
--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -15,6 +15,9 @@ export default function Page() {
       <Link href={"/components/horizontal-small-chef-list"} className={"hover:text-blue-11 hover:underline"}>
         HorizontalSmallChefListコンポーネント
       </Link>
+      <Link href={"/components/vertical-recipe-list"} className={"hover:text-blue-11 hover:underline"}>
+        VerticalRecipeListコンポーネント
+      </Link>
     </main>
   );
 }

--- a/src/app/components/vertical-recipe-list/page.tsx
+++ b/src/app/components/vertical-recipe-list/page.tsx
@@ -1,0 +1,22 @@
+import { VerticalRecipeList } from "@/components/vertical-recipe-list/vertical-recipe-list";
+
+export default function Page() {
+  const recipeList = Array.from({ length: 10 }).map(
+    (_, i) =>
+      ({
+        id: 1,
+        href: `/recipe`,
+        image: "/images/recipe_01.png",
+        name: "自家燻製したノルウェーサーモンと帆立貝柱のムースのキャベツ包み蒸し 生雲丹とパセリのヴルーテ",
+        chefName: "中々田中ジェフシェフの超々最長ミシシッピレシピ収集",
+        favoriteCount: 1234,
+        isPublic: true,
+      } as const)
+  );
+
+  return (
+    <div className="px-4">
+      <VerticalRecipeList recipeList={recipeList} />
+    </div>
+  );
+}

--- a/src/components/recipe-list-item/recipe-list-item.tsx
+++ b/src/components/recipe-list-item/recipe-list-item.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 import { TbHeart } from "react-icons/tb";
 
-type RecipeListItem<T extends string> = {
+export type RecipeListItem<T extends string> = {
   id: number;
   href: Route<T>;
   image: string;
@@ -19,11 +19,7 @@ const imageSize = 192;
 
 export const RecipeListItem = <T extends string>({ recipeListItem }: { recipeListItem: RecipeListItem<T> }) => {
   return (
-    <Link
-      href={recipeListItem.href}
-      key={recipeListItem.id}
-      className="relative flex flex-col items-start justify-center gap-2"
-    >
+    <Link href={recipeListItem.href} className="relative flex flex-col items-start justify-center gap-2">
       <Image
         className="aspect-square w-full rounded-2xl bg-tomato-3"
         width={imageSize}

--- a/src/components/vertical-recipe-list/vertical-recipe-list.tsx
+++ b/src/components/vertical-recipe-list/vertical-recipe-list.tsx
@@ -1,0 +1,15 @@
+import { RecipeListItem } from "@/components/recipe-list-item/recipe-list-item";
+
+export const VerticalRecipeList = <T extends string>({ recipeList }: { recipeList: RecipeListItem<T>[] }) => {
+  return (
+    <div className="grid grid-cols-2 gap-x-3 gap-y-4">
+      {recipeList.map((recipeListItem) => {
+        return (
+          <div className="w-full" key={recipeListItem.id}>
+            <RecipeListItem recipeListItem={recipeListItem} />
+          </div>
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
## issue
- https://github.com/qin-team-recipe/08-recipe-app/issues/60

## URL
- http://localhost:3000/components/vertical-recipe-list

## 対応内容・対応妥協点

### 対応内容
- VerticalRecipeListコンポーネント作成
- RecipeListItemコンポーネント微修正（型をexportとLinkのkeyを削除）

### 対応妥協点
- FigmaのFlexを使っている形で作ろうとしたが、RecipeListItemコンポーネントを2つずつでdivで括るとなると条件式を作る必要がある。条件式を作ってdivで括るよりはgridを使う方が見やすいと思い、gridを採用しました。

## UI
### PC
![image](https://github.com/qin-team-recipe/08-recipe-app/assets/73679908/342be9c5-a010-4fdc-8ef9-8f4a9df2772c)
### SP
![image](https://github.com/qin-team-recipe/08-recipe-app/assets/73679908/3dec791d-3aa7-45be-9b03-337a110842c3)

## レビュー観点
- 正常に表示できるか
- 型エラー等出ていないか
- gridに変更した問題がないか