### PR TITLE
シェフ詳細ページ デザイン部分作成

### DIFF
--- a/src/app/chef/[id]/layout.tsx
+++ b/src/app/chef/[id]/layout.tsx
@@ -1,9 +1,22 @@
 import { ChefDetail } from "@/components/chef-detail/chef-detail";
+import { Tabs } from "@/components/tabs/tabs";
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ params, children }: { params: { id: number }; children: React.ReactNode }) {
   return (
-    <main>
+    <main className="flex w-full flex-col items-start gap-5 self-stretch">
       <ChefDetail />
+      <Tabs
+        tabList={[
+          {
+            name: "新着レシピ",
+            href: `/chef/${params.id}`,
+          },
+          {
+            name: "人気レシピ",
+            href: `/chef/${params.id}/popular`,
+          },
+        ]}
+      ></Tabs>
       {children}
     </main>
   );

--- a/src/app/chef/[id]/popular/page.tsx
+++ b/src/app/chef/[id]/popular/page.tsx
@@ -6,7 +6,7 @@ export default function Page({ params }: { params: { id: string } }) {
       ({
         id: i,
         href: `/recipe`,
-        image: "/images/recipe_01.png",
+        image: "/images/recipe_02.png",
         name: "自家燻製したノルウェーサーモンと帆立貝柱のムースのキャベツ包み蒸し 生雲丹とパセリのヴルーテ",
         chefName: "中々田中ジェフシェフの超々最長ミシシッピレシピ収集",
         favoriteCount: 1234,

--- a/src/components/chef-detail/chef-detail.tsx
+++ b/src/components/chef-detail/chef-detail.tsx
@@ -19,7 +19,7 @@ export const ChefDetail = () => {
   };
 
   return (
-    <div className="p-4">
+    <div className="flex w-full flex-col px-4 pt-4">
       <div className="mb-2 flex items-start justify-between">
         <BackButton />
         {/* リンクボタンはコンポーネント化予定 */}
@@ -57,7 +57,6 @@ export const ChefDetail = () => {
           </div>
         ))}
       </div>
-      {/* フォローするボタンはコンポーネント化予定 */}
       <ChefFollowButton />
     </div>
   );

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -15,7 +15,7 @@ type TabsProps<T extends string> = {
 export const Tabs = <T extends string>(props: TabsProps<T>) => {
   const pathname = usePathname();
   return (
-    <div className="text-center text-sm font-medium">
+    <div className="w-full text-center text-sm font-medium">
       <div className="flex flex-wrap">
         {props.tabList.map((link) => {
           const isActive = pathname == link.href;

--- a/src/features/users/components/chef-follow-button.tsx
+++ b/src/features/users/components/chef-follow-button.tsx
@@ -2,16 +2,17 @@
 
 import { useState } from "react";
 
+import { Button } from "@/components/button/button";
+
 export const ChefFollowButton = () => {
   const [isFollow, setFollow] = useState(false);
   const toggleFollow = () => setFollow(!isFollow);
-  const followButtonToggleStyle = isFollow
-    ? "bg-tomato-solid border-transparent"
-    : "border-tomato-normal text-tomato-dim";
 
-  return (
-    <button onClick={toggleFollow} className={`w-full rounded-md  border px-3 py-1 text-sm ${followButtonToggleStyle}`}>
-      {isFollow ? "フォローする" : "フォロー中"}
-    </button>
+  return isFollow ? (
+    <Button onClick={toggleFollow}>フォローする</Button>
+  ) : (
+    <Button variant="tomatoOutline" onClick={toggleFollow}>
+      フォロー中
+    </Button>
   );
 };


### PR DESCRIPTION
## issue
- https://github.com/qin-team-recipe/08-recipe-app/issues/16

## URL
- http://localhost:3000/chef/1
- http://localhost:3000/chef/1/popular

## 対応内容・対応妥協点

### 対応内容
- ChefDetailコンポーネント・Tabコンポーネント・VerticalRecipeListコンポーネントを組み合わせてシェフ詳細ページのデザイン部分を作成
- ChefFollowButtonコンポーネントでButtonコンポーネントを使用して「フォローする」と「フォロー中」を切り替え
- Tabコンポーネントにw-fullを追加
- ChefDetailコンポーネントの全体レイアウト変更

### 対応妥協点
- 右上のリンクボタンに関してはデザインのみで、押しても何も起きません。
- データの型などはバックエンドとの繋ぎ込みの時に修正します。(idがnumとstringで混合してますが無視してください。)
- ←ボタン（戻るボタン）については結局どうなるのか不明なためそのまま

## UI
<img width="738" alt="image" src="https://github.com/qin-team-recipe/08-recipe-app/assets/73679908/4d3a22d2-b103-4d96-894f-b91235305c6c">


## レビュー観点
- 正常に表示できるか
- 「フォローする」と「フォロー中」を切り替えができるか