### PR TITLE
プロフィール編集コンポーネント作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prisma-kysely": "^1.5.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.45.4",
     "react-icons": "^4.10.1",
     "server-only": "^0.0.1",
     "swagger-ui-react": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.4",
     "react-icons": "^4.10.1",
+    "react-textarea-autosize": "^8.5.2",
     "server-only": "^0.0.1",
     "swagger-ui-react": "^5.3.1",
     "tailwind-merge": "^1.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ dependencies:
   react-icons:
     specifier: ^4.10.1
     version: 4.10.1(react@18.2.0)
+  react-textarea-autosize:
+    specifier: ^8.5.2
+    version: 8.5.2(@types/react@18.2.18)(react@18.2.0)
   server-only:
     specifier: ^0.0.1
     version: 0.0.1
@@ -1494,6 +1497,7 @@ packages:
 
   /@swagger-api/apidom-ns-json-schema-draft-4@0.74.1:
     resolution: {integrity: sha512-zUQvrxoRQpvdYymHko1nxNeVWwqdGDYNYWUFW/EGZbP0sigKmuSZkh6LdseB9Pxt1WQD/6MkW3zN4JMXt/qFUA==}
+    requiresBuild: true
     dependencies:
       '@babel/runtime-corejs3': 7.22.10
       '@swagger-api/apidom-ast': 0.74.1
@@ -5610,6 +5614,20 @@ packages:
       refractor: 3.6.0
     dev: false
 
+  /react-textarea-autosize@8.5.2(@types/react@18.2.18)(react@18.2.0):
+    resolution: {integrity: sha512-uOkyjkEl0ByEK21eCJMHDGBAAd/BoFQBawYK5XItjAmCTeSbjxghd8qnt7nzsLYzidjnoObu6M26xts0YGKsGg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.22.10
+      react: 18.2.0
+      use-composed-ref: 1.3.0(react@18.2.0)
+      use-latest: 1.2.1(@types/react@18.2.18)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -6771,6 +6789,41 @@ packages:
       '@types/react': 18.2.18
       react: 18.2.0
       tslib: 2.6.1
+    dev: false
+
+  /use-composed-ref@1.3.0(react@18.2.0):
+    resolution: {integrity: sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.18)(react@18.2.0):
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.18
+      react: 18.2.0
+    dev: false
+
+  /use-latest@1.2.1(@types/react@18.2.18)(react@18.2.0):
+    resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.18
+      react: 18.2.0
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.18)(react@18.2.0)
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.18)(react@18.2.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ dependencies:
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
+  react-hook-form:
+    specifier: ^7.45.4
+    version: 7.45.4(react@18.2.0)
   react-icons:
     specifier: ^4.10.1
     version: 4.10.1(react@18.2.0)
@@ -5445,6 +5448,15 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-hook-form@7.45.4(react@18.2.0):
+    resolution: {integrity: sha512-HGDV1JOOBPZj10LB3+OZgfDBTn+IeEsNOKiq/cxbQAIbKaiJUe/KV8DBUzsx0Gx/7IG/orWqRRm736JwOfUSWQ==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-icons@4.10.1(react@18.2.0):

--- a/src/app/components/form/page.tsx
+++ b/src/app/components/form/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+
+import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
+
+import { Button } from "@/components/button/button";
+import { ImageInputField, InputField, MultiInputsField, TextareaField } from "@/components/form";
+
+type FormValues = {
+  inputField: string;
+  imageField: string;
+  textAreaField: string;
+  multiInputsField: {
+    value: string;
+  }[];
+};
+
+export default function Page() {
+  const methods = useForm<FormValues>();
+
+  const onSubmit: SubmitHandler<FormValues> = (data) => console.log(data);
+
+  return (
+    <main className="grid gap-4 pt-4">
+      <Link href={"/components"} className={"hover:text-blue-11 hover:underline pl-4"}>
+        戻る
+      </Link>
+
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)} className="grid gap-4">
+          <InputField name="inputField" label="インプットフィールド" placeholder="テキストを入力" />
+
+          <ImageInputField name="imageField" label="イメージインプットフィールド" />
+
+          <TextareaField fieldName="textAreaField" placeholder="テキストエリアフィールド" label="テキストを入力" minRows={3} />
+
+          <MultiInputsField label="マルチインプットフィールド" fieldName="multiInputsField" placeholder="テキストを入力" maxRows={5} />
+
+          <Button>submit</Button>
+        </form>
+      </FormProvider>
+    </main>
+  );
+}

--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -18,6 +18,9 @@ export default function Page() {
       <Link href={"/components/vertical-recipe-list"} className={"hover:text-blue-11 hover:underline"}>
         VerticalRecipeListコンポーネント
       </Link>
+      <Link href={"/components/form"} className={"hover:text-blue-11 hover:underline"}>
+        Formコンポーネント
+      </Link>
     </main>
   );
 }

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { FormProvider, useForm } from "react-hook-form";
+
+import { Button } from "@/components/button/button";
+import { ImageInputField, InputField, MultiInputsField, TextareaField } from "@/components/form";
+
+export default function Page() {
+  const methods = useForm({
+    defaultValues: {
+      // TODO: すでに入力済みの項目はここに入れる
+      links: [{ value: "" }],
+    },
+  });
+  // TODO: 保存するを押したときの処理
+  // eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any
+  const onSubmit = (data: any) => console.log(data);
+
+  return (
+    <FormProvider {...methods}>
+      <h1 className="border-b border-mauve-6 px-4 py-3 text-center text-xl font-bold">編集</h1>
+      <form className="mt-5 space-y-8" onSubmit={methods.handleSubmit(onSubmit)}>
+        <InputField name="nickname" label="ニックネーム" placeholder="ニックネームを入力" />
+
+        <ImageInputField name="profileImage" label="プロフィール画像（任意）" />
+
+        <TextareaField fieldName="introduction" placeholder="自己紹介を入力" label="自己紹介（任意）" minRows={3} />
+
+        <MultiInputsField label="リンク（任意）" fieldName="links" placeholder="リンクを入力" maxRows={5} />
+
+        <div className="flex justify-center space-x-4 px-4">
+          <Button>保存する</Button>
+          <Button type="button" variant={"tomatoOutline"}>
+            キャンセル
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -1,20 +1,24 @@
 "use client";
 
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
 
 import { Button } from "@/components/button/button";
 import { ImageInputField, InputField, MultiInputsField, TextareaField } from "@/components/form";
 
+type FormValues = {
+  nickname: string;
+  profileImage?: string;
+  introduction?: string;
+  links?: {
+    value: string;
+  }[];
+};
+
 export default function Page() {
-  const methods = useForm({
-    defaultValues: {
-      // TODO: すでに入力済みの項目はここに入れる
-      links: [{ value: "" }],
-    },
-  });
+  const methods = useForm<FormValues>();
   // TODO: 保存するを押したときの処理を記載
-  // eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any
-  const onSubmit = (data: any) => console.log(data);
+  // eslint-disable-next-line no-console
+  const onSubmit: SubmitHandler<FormValues> = (data) => console.log(data);
 
   return (
     <FormProvider {...methods}>

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
       links: [{ value: "" }],
     },
   });
-  // TODO: 保存するを押したときの処理
+  // TODO: 保存するを押したときの処理を記載
   // eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any
   const onSubmit = (data: any) => console.log(data);
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,5 +1,6 @@
 export default function Page() {
   return (
+    // TODO: これはprofile editページを作成したときに使用した仮のページです。必要に応じて修正お願いします。
     <div>
       <h1>this is my page </h1>
     </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>this is my page </h1>
+    </div>
+  );
+}

--- a/src/components/form/add-input-button.tsx
+++ b/src/components/form/add-input-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AiOutlinePlus } from "react-icons/ai";
+import { TbPlus } from "react-icons/tb";
 
 import { cn } from "@/lib/utils";
 
@@ -11,7 +11,7 @@ type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 export const AddInputButton = ({ text, className, ...props }: Props) => {
   return (
     <button type="button" className={cn("flex", className)} {...props}>
-      <AiOutlinePlus className="h-4 w-4 fill-tomato-9" />
+      <TbPlus className="h-4 w-4 stroke-tomato-9" />
       <span className="text-sm leading-4 text-tomato-9">{text}</span>
     </button>
   );

--- a/src/components/form/add-input-button.tsx
+++ b/src/components/form/add-input-button.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { AiOutlinePlus } from "react-icons/ai";
+
+import { cn } from "@/lib/utils";
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  text: string;
+};
+
+export const AddInputButton = ({ text, className, ...props }: Props) => {
+  return (
+    <button type="button" className={cn("flex", className)} {...props}>
+      <AiOutlinePlus className="h-4 w-4 fill-tomato-9" />
+      <span className="text-sm leading-4 text-tomato-9">{text}</span>
+    </button>
+  );
+};

--- a/src/components/form/image-input-field.tsx
+++ b/src/components/form/image-input-field.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { ChangeEvent, useRef, useState } from "react";
+import Image from "next/image";
+
+import { Controller, useFormContext } from "react-hook-form";
+import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
+
+type Props = {
+  name: string;
+  label: string;
+};
+
+export const ImageInputField = (props: Props) => {
+  const { name, label } = props;
+  const [previewImage, setPreviewImage] = useState<string | undefined>(undefined);
+  const { control, setValue } = useFormContext();
+  const inputFileRef = useRef<HTMLInputElement>(null);
+
+  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setValue(name, file);
+      setPreviewImage(URL.createObjectURL(file));
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setValue(name, undefined);
+    setPreviewImage(undefined);
+  };
+
+  return (
+    <div className="flex flex-col space-y-2 px-4">
+      <label className="font-bold">{label}</label>
+
+      {previewImage ? (
+        <div className="relative w-[100px]">
+          <Image
+            src={previewImage}
+            width={100}
+            height={100}
+            className="h-[100px] w-[100px] rounded-lg object-cover"
+            alt="profile image"
+          />
+          <button
+            className="absolute -right-2 -top-2 h-5 w-5 rounded-full bg-tomato-9"
+            onClick={handleRemoveImage}
+            type="button"
+          >
+            <AiOutlineMinus className="mx-auto h-4 w-4 fill-whitea-13" />
+          </button>
+        </div>
+      ) : (
+        <Controller
+          name={name}
+          control={control}
+          render={({ field }) => (
+            <button
+              type="button"
+              onClick={() => inputFileRef.current?.click()}
+              className="h-[100px] w-[100px] rounded-lg border px-4 py-7 "
+            >
+              <input
+                {...field}
+                ref={inputFileRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(event) => {
+                  field.onChange(event);
+                  handleImageChange(event);
+                }}
+              />
+              <div>
+                <label className="text-xs text-mauve-11">画像を設定</label>
+                <AiOutlinePlus className="mx-auto fill-mauve-11" />
+              </div>
+            </button>
+          )}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/components/form/image-input-field.tsx
+++ b/src/components/form/image-input-field.tsx
@@ -4,8 +4,7 @@ import { ChangeEvent, useRef, useState } from "react";
 import Image from "next/image";
 
 import { Controller, useFormContext } from "react-hook-form";
-import { TbPlus, TbMinus } from "react-icons/tb";
-
+import { TbMinus, TbPlus } from "react-icons/tb";
 
 type Props = {
   name: string;
@@ -60,7 +59,7 @@ export const ImageInputField = (props: Props) => {
             <button
               type="button"
               onClick={() => inputFileRef.current?.click()}
-              className="h-[100px] w-[100px] rounded-lg border px-4 py-7 "
+              className="h-[100px] w-[100px] rounded-lg border px-4 py-7"
             >
               <input
                 {...field}

--- a/src/components/form/image-input-field.tsx
+++ b/src/components/form/image-input-field.tsx
@@ -4,7 +4,8 @@ import { ChangeEvent, useRef, useState } from "react";
 import Image from "next/image";
 
 import { Controller, useFormContext } from "react-hook-form";
-import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai";
+import { TbPlus, TbMinus } from "react-icons/tb";
+
 
 type Props = {
   name: string;
@@ -48,7 +49,7 @@ export const ImageInputField = (props: Props) => {
             onClick={handleRemoveImage}
             type="button"
           >
-            <AiOutlineMinus className="mx-auto h-4 w-4 fill-whitea-13" />
+            <TbMinus className="mx-auto h-4 w-4 stroke-whitea-13" />
           </button>
         </div>
       ) : (
@@ -74,7 +75,7 @@ export const ImageInputField = (props: Props) => {
               />
               <div>
                 <label className="text-xs text-mauve-11">画像を設定</label>
-                <AiOutlinePlus className="mx-auto fill-mauve-11" />
+                <TbPlus className="mx-auto stroke-mauve-11" />
               </div>
             </button>
           )}

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,0 +1,4 @@
+export * from "./input-field";
+export * from "./image-input-field";
+export * from "./text-area-field"
+export * from "./multi-inputs-field"

--- a/src/components/form/input-field.tsx
+++ b/src/components/form/input-field.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useFormContext } from "react-hook-form";
+
+type Props = {
+  name: string;
+  label?: string;
+  placeholder?: string;
+};
+
+export const InputField = (props: Props) => {
+  const { name, label, placeholder } = props;
+  const { register } = useFormContext();
+  return (
+    <div className="space-y-1">
+      <label className="px-4 font-bold">{label}</label>
+      <input
+        type="text"
+        placeholder={placeholder}
+        className="w-full appearance-none rounded-none border-y px-4 py-3"
+        {...register(name)}
+      />
+    </div>
+  );
+};

--- a/src/components/form/multi-inputs-field.tsx
+++ b/src/components/form/multi-inputs-field.tsx
@@ -24,7 +24,7 @@ export const MultiInputsField = (props: Props) => {
           <input
             type="text"
             placeholder={placeholder}
-            className={`${index == 0 && "border-t"} w-full appearance-none rounded-none border-b px-4 py-3`}
+            className={`${index === 0 && "border-t"} w-full appearance-none rounded-none border-b px-4 py-3`}
             {...register(`${fieldName}.${index}.value` as const)}
           />
           {/* TODO: 仮で置いてる削除ボタンです。ちゃんとしたものに置き換える */}

--- a/src/components/form/multi-inputs-field.tsx
+++ b/src/components/form/multi-inputs-field.tsx
@@ -4,6 +4,7 @@ import { useFieldArray, useFormContext } from "react-hook-form";
 import { TbTrash } from "react-icons/tb";
 
 import { AddInputButton } from "@/components/form/add-input-button";
+import { cn } from "@/lib/utils";
 
 type Props = {
   fieldName: string;
@@ -16,6 +17,8 @@ export const MultiInputsField = (props: Props) => {
   const { fieldName, label, maxRows, placeholder } = props;
   const { control, register } = useFormContext();
   const { append, fields, remove } = useFieldArray({ name: fieldName, control });
+
+  console.log(fields);
 
   return (
     <div>
@@ -35,12 +38,15 @@ export const MultiInputsField = (props: Props) => {
           <input
             type="text"
             placeholder={placeholder}
-            className={`${index === 0 && "border-t"} w-full appearance-none rounded-none border-b px-4 py-3`}
+            className={cn(
+              "w-full appearance-none rounded-none border-b px-4 py-3",
+              index === 0 && "border-t",
+              index !== 0 && "pr-11",
+            )}
             {...register(`${fieldName}.${index}.value` as const)}
           />
-          {/* TODO: 仮で置いてる削除ボタンです。ちゃんとしたものに置き換える */}
           {index !== 0 && (
-            <button type="button" className="absolute right-4 hover:opacity-60" onClick={() => remove(index)}>
+            <button type="button" className="absolute right-3 hover:opacity-60" onClick={() => remove(index)}>
               <TbTrash className="h-6 w-6 stroke-mauve-11 stroke-[1.5]" />
             </button>
           )}

--- a/src/components/form/multi-inputs-field.tsx
+++ b/src/components/form/multi-inputs-field.tsx
@@ -18,8 +18,6 @@ export const MultiInputsField = (props: Props) => {
   const { control, register } = useFormContext();
   const { append, fields, remove } = useFieldArray({ name: fieldName, control });
 
-  console.log(fields);
-
   return (
     <div>
       <label className="mb-1 px-4 font-bold">{label}</label>

--- a/src/components/form/multi-inputs-field.tsx
+++ b/src/components/form/multi-inputs-field.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useFieldArray, useFormContext } from "react-hook-form";
+import { TbTrash } from "react-icons/tb";
 
 import { AddInputButton } from "@/components/form/add-input-button";
 
@@ -24,7 +25,7 @@ export const MultiInputsField = (props: Props) => {
         <input
           type="text"
           placeholder={placeholder}
-          className={"border-t w-full appearance-none rounded-none border-b px-4 py-3"}
+          className={"w-full appearance-none rounded-none border-y px-4 py-3"}
           {...register(`${fieldName}.0.value` as const)}
         />
       )}
@@ -39,8 +40,8 @@ export const MultiInputsField = (props: Props) => {
           />
           {/* TODO: 仮で置いてる削除ボタンです。ちゃんとしたものに置き換える */}
           {index !== 0 && (
-            <button type="button" className="absolute right-3" onClick={() => remove(index)}>
-              削除
+            <button type="button" className="absolute right-4 hover:opacity-60" onClick={() => remove(index)}>
+              <TbTrash className="h-6 w-6 stroke-mauve-11 stroke-[1.5]" />
             </button>
           )}
         </div>

--- a/src/components/form/multi-inputs-field.tsx
+++ b/src/components/form/multi-inputs-field.tsx
@@ -19,6 +19,16 @@ export const MultiInputsField = (props: Props) => {
   return (
     <div>
       <label className="mb-1 px-4 font-bold">{label}</label>
+
+      {fields.length === 0 && (
+        <input
+          type="text"
+          placeholder={placeholder}
+          className={"border-t w-full appearance-none rounded-none border-b px-4 py-3"}
+          {...register(`${fieldName}.0.value` as const)}
+        />
+      )}
+
       {fields.map((item, index) => (
         <div key={item.id} className="relative flex items-center justify-end">
           <input

--- a/src/components/form/multi-inputs-field.tsx
+++ b/src/components/form/multi-inputs-field.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useFieldArray, useFormContext } from "react-hook-form";
+
+import { AddInputButton } from "@/components/form/add-input-button";
+
+type Props = {
+  fieldName: string;
+  label: string;
+  maxRows: number;
+  placeholder?: string;
+};
+
+export const MultiInputsField = (props: Props) => {
+  const { fieldName, label, maxRows, placeholder } = props;
+  const { control, register } = useFormContext();
+  const { append, fields, remove } = useFieldArray({ name: fieldName, control });
+
+  return (
+    <div>
+      <label className="mb-1 px-4 font-bold">{label}</label>
+      {fields.map((item, index) => (
+        <div key={item.id} className="relative flex items-center justify-end">
+          <input
+            type="text"
+            placeholder={placeholder}
+            className={`${index == 0 && "border-t"} w-full appearance-none rounded-none border-b px-4 py-3`}
+            {...register(`${fieldName}.${index}.value` as const)}
+          />
+          {/* TODO: 仮で置いてる削除ボタンです。ちゃんとしたものに置き換える */}
+          {index !== 0 && (
+            <button type="button" className="absolute right-3" onClick={() => remove(index)}>
+              削除
+            </button>
+          )}
+        </div>
+      ))}
+
+      {fields.length < maxRows && (
+        <AddInputButton className="mx-4 mt-2" text="リンクを追加する" onClick={() => append({ value: "" })} />
+      )}
+    </div>
+  );
+};

--- a/src/components/form/text-area-field.tsx
+++ b/src/components/form/text-area-field.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useFormContext } from "react-hook-form";
+import TextareaAutosize from "react-textarea-autosize";
+
+type Props = {
+  fieldName: string;
+  label: string;
+  maxRows?: number;
+  minRows?: number;
+  placeholder?: string;
+};
+
+export const TextareaField = (props: Props) => {
+  const { fieldName, label, maxRows, minRows, placeholder } = props;
+  const { register } = useFormContext();
+
+  return (
+    <div className="flex flex-col space-y-1">
+      <label className="px-4 font-bold">{label}</label>
+      <TextareaAutosize
+        minRows={minRows}
+        maxRows={maxRows}
+        placeholder={placeholder}
+        className="w-full resize-none appearance-none rounded-none border-y px-4 py-3"
+        {...register(fieldName)}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Issue
close #67

## 実施内容
プロフィール編集コンポーネントの作成
1. インプットフィールド
2. マルチインプットフィールド
3. 画像インプットフィールド
4. テキストインプットフィールド

## UI
<img width="1080" alt="image" src="https://github.com/qin-team-recipe/08-recipe-app/assets/61902151/9f2dabf2-01e3-481c-b00b-83e9de50a36d">


## 確認したい事項
- マルチインプットフィールドの削除ボタンのUI (Figmaには削除ボタンはない)
- zod使ってのバリデーションも考慮したほうがいいでしょうか？現状バリデーションが考慮できていなくて。。。