### PR TITLE
全体のスタイル・サイドバーのリンクの微調整

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,10 +10,10 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja" suppressHydrationWarning>
-      <body>
+      <body className="bg-mauve-1">
         <div className="mx-auto flex min-h-screen sm:max-w-2xl sm:gap-x-3 sm:px-4">
           <Navigation />
-          <div className="flex-1 overflow-hidden pb-20 sm:border-x">{children}</div>
+          <div className="flex-1 overflow-hidden pb-20 sm:border-x sm:border-mauve-6">{children}</div>
         </div>
       </body>
     </html>

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -6,12 +6,12 @@ import { AiOutlineHeart, AiOutlineSearch, AiOutlineShoppingCart } from "react-ic
 
 export const Navigation = () => {
   return (
-    <nav className="bg-whitea-13 fixed bottom-0 z-50 w-full sm:sticky sm:w-auto sm:self-start">
+    <nav className="fixed bottom-0 z-50 w-full bg-whitea-13 sm:sticky sm:w-auto sm:self-start">
       <div className="hidden sm:block  sm:px-3 sm:py-2">ロゴ</div>
       <div className="flex cursor-pointer gap-1 border-t sm:flex-col sm:border-none">
         <NavigationItem label="さがす" icon={<AiOutlineSearch />} href={"/"} />
-        <NavigationItem label="お気に入り" icon={<AiOutlineHeart />} href={"/"} />
-        <NavigationItem label="お買い物" icon={<AiOutlineShoppingCart />} href={"/"} />
+        <NavigationItem label="お気に入り" icon={<AiOutlineHeart />} href={"/fav"} />
+        <NavigationItem label="お買い物" icon={<AiOutlineShoppingCart />} href={"/list"} />
       </div>
     </nav>
   );

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -6,7 +6,7 @@ import { AiOutlineHeart, AiOutlineSearch, AiOutlineShoppingCart } from "react-ic
 
 export const Navigation = () => {
   return (
-    <nav className="fixed bottom-0 z-50 w-full bg-whitea-13 sm:sticky sm:w-auto sm:self-start">
+    <nav className="fixed bottom-0 z-50 w-full bg-mauve-1 sm:sticky sm:w-auto sm:self-start">
       <div className="hidden sm:block  sm:px-3 sm:py-2">ロゴ</div>
       <div className="flex cursor-pointer gap-1 border-t sm:flex-col sm:border-none">
         <NavigationItem label="さがす" icon={<AiOutlineSearch />} href={"/"} />


### PR DESCRIPTION
## 内容
- 全体の背景色を`bg-mauve-1`に
- メインコンテンツのborderを`mauve-6`に
- サイドバーのリンクのパスを通した


## 動作確認
サイドバーリンクでページ遷移すること
スタイルが当たっていること
<img width="699" alt="image" src="https://github.com/qin-team-recipe/08-recipe-app/assets/57983394/740becca-1975-458a-9293-605eb7406c24">
