### PR TITLE
#93 [提案][優先度低] 検索フォームを空にする処理をsearch-sectionコンポーネントに移動

### DIFF
--- a/src/app/(search)/layout.tsx
+++ b/src/app/(search)/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ElementRef, PropsWithChildren, useRef } from "react";
+import { PropsWithChildren } from "react";
 import { Route } from "next";
 import { usePathname, useSearchParams } from "next/navigation";
 
@@ -32,20 +32,14 @@ export default function Layout({ children }: PropsWithChildren) {
     return { name, href };
   });
 
-  const ref = useRef<ElementRef<"input">>(null);
-  const { current } = ref;
   const isRoot = route === "/";
-
-  if (current && isRoot) {
-    current.value = "";
-  }
 
   return (
     <main>
       {isRoot ? (
-        <SearchSection q={q} route="/search/recipe" ref={ref} />
+        <SearchSection q={q} replaceRoute="/search/recipe" />
       ) : (
-        <SearchSection q={q} route={route} href="/" ref={ref}>
+        <SearchSection q={q} replaceRoute={route} href="/">
           <Tabs tabList={tabList} />
         </SearchSection>
       )}

--- a/src/features/search/components/search-section.tsx
+++ b/src/features/search/components/search-section.tsx
@@ -1,24 +1,39 @@
 "use client";
 
-import { ElementRef, forwardRef, PropsWithChildren, useRef, useTransition } from "react";
+import { ElementRef, ReactNode, useRef, useTransition } from "react";
 import { Route } from "next";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 import { TbArrowLeft } from "react-icons/tb";
-import { mergeRefs } from "react-merge-refs";
 
 import { SearchInput } from "./search-input";
 
-export const SearchSection = forwardRef<
-  ElementRef<"input">,
-  PropsWithChildren<{ q: string; route: Route; href?: Route }>
->(({ q, route, href, children }, ref) => {
+export const SearchSection = ({
+  q,
+  replaceRoute,
+  href,
+  children,
+}: {
+  q: string;
+  replaceRoute: Route;
+  href?: Route;
+  children?: ReactNode;
+}) => {
   const [isPending, startTransition] = useTransition();
   const { replace } = useRouter();
+  const pathname = usePathname();
+  const route =
+    (["/", "/search/recipe", "/search/chef"] as const satisfies ReadonlyArray<Route>).find(
+      (route) => route === pathname,
+    ) ?? ("/search/recipe" satisfies Route);
 
   const inputRef = useRef<ElementRef<"input">>(null);
   const { current } = inputRef;
+
+  if (!isPending && current && route === "/") {
+    current.value = "";
+  }
 
   return (
     <section>
@@ -38,11 +53,11 @@ export const SearchSection = forwardRef<
                 });
                 const q = event.target.value.trim();
                 if (q === "") {
-                  replace(route);
+                  replace(replaceRoute);
                   return;
                 }
                 const params = new URLSearchParams({ q });
-                replace(`${route}?${params}`);
+                replace(`${replaceRoute}?${params}`);
               });
             }}
             isPending={isPending}
@@ -50,15 +65,15 @@ export const SearchSection = forwardRef<
             onClick={() => {
               if (!current) return;
               current.value = "";
-              replace(route);
+              replace(replaceRoute);
             }}
-            ref={mergeRefs([ref, inputRef])}
+            ref={inputRef}
           />
         </div>
       </div>
       {children}
     </section>
   );
-});
+};
 
 SearchSection.displayName = "SearchSection";


### PR DESCRIPTION
- #93 について、検索フォームを空にする処理をlayoutからsearch-sectionコンポーネントに移動できたので提案させてください
- あくまで提案です（他を優先で）
- 上記移動によりmerge-refを使わなくてよくなっています
- 一通り動作確認したつもりですが、不備あったら申し訳ないです