### PR TITLE
🔧 kyselyのQueryログを開発環境で出すようにした

### DIFF
--- a/src/lib/kysely.ts
+++ b/src/lib/kysely.ts
@@ -1,6 +1,20 @@
 import { Codegen, KyselyAuth } from "@auth/kysely-adapter";
+import { LogEvent } from "kysely";
 
 import { dialect } from "@/lib/kysely-node";
 import { DB } from "@/types/db";
 
-export const db = new KyselyAuth<DB, Codegen>({ dialect });
+const kyselyConfig = {
+  dialect,
+  ...(process.env.NODE_ENV === "development" && {
+    log: (event: LogEvent) => {
+      if (event.level == "query") {
+        const q = event.query;
+        const time = Math.round(event.queryDurationMillis * 100) / 100;
+        console.log(`\u001b[32mkysely:sql\u001b[0m [${q.sql}] parameters: [${q.parameters}] time: ${time}`);
+      }
+    },
+  }),
+};
+
+export const db = new KyselyAuth<DB, Codegen>(kyselyConfig);


### PR DESCRIPTION
## 内容
- 表題の通りで、軽微な修正のためIssue立てていません

## 確認方法
- レビュワーの任意のkysely実行処理時に、ターミナルでその実行したクエリログが表示される（下記例）
<img width="1357" alt="スクリーンショット 2023-09-14 23 05 36" src="https://github.com/qin-team-recipe/08-recipe-app/assets/25321850/6d62c90a-c0cb-4ba2-8927-638332650505">
