### PR TITLE
[提案]退会処理の確認ダイアログ作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@hookform/resolvers": "^3.3.1",
     "@planetscale/database": "^1.11.0",
     "@prisma/client": "5.3.1",
+    "@radix-ui/react-alert-dialog": "^1.0.4",
     "@radix-ui/react-avatar": "^1.0.3",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   '@prisma/client':
     specifier: 5.3.1
     version: 5.3.1(prisma@5.3.1)
+  '@radix-ui/react-alert-dialog':
+    specifier: ^1.0.4
+    version: 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-avatar':
     specifier: ^1.0.3
     version: 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
@@ -956,6 +959,32 @@ packages:
       '@babel/runtime': 7.22.15
     dev: false
 
+  /@radix-ui/react-alert-dialog@1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-jbfBCRlKYlhbitueOAv7z74PXYeIQmWpKwm3jllsdkw7fGWNkxqP3v0nY9WmOzcPqpQuoorNtvViBgL46n5gVg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-dialog': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==}
     peerDependencies:
@@ -1079,6 +1108,40 @@ packages:
       '@babel/runtime': 7.22.15
       '@types/react': 18.2.22
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-dialog@1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-hJtRy/jPULGQZceSAP2Re6/4NpKo8im6V8P2hUqZsdFiSL8l35kYsw3qbRI6Ay5mQd2+wlLqje770eq+RJ3yZg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.22)(react@18.2.0)
     dev: false
 
   /@radix-ui/react-direction@1.0.1(@types/react@18.2.22)(react@18.2.0):

--- a/src/app/settings/delete-user-button.tsx
+++ b/src/app/settings/delete-user-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Updateable } from "kysely";
+import { TbAlertCircle } from "react-icons/tb";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/alert-dialog/alert-dialog";
+import { User } from "@/types/db";
+
+type UserId = Exclude<Updateable<User>["id"], undefined>;
+
+export default function DeleteUserButon({ userId }: { userId: UserId }) {
+  const router = useRouter();
+
+  const deleteUser = (userId: UserId) => {
+    console.log("deleteUser called", "userId", userId);
+    //TODO:1.退会処理
+    //TODO:2.退会完了画面へ遷移
+    router.push("/"); //仮でトップへ遷移
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <button className="flex justify-between px-4 py-3">
+          <span>退会する</span>
+          <TbAlertCircle className="h-6 w-6" />
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>本当に退会してよろしいですか?</AlertDialogTitle>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-col">
+          <AlertDialogAction onClick={() => deleteUser(userId)}>退会する</AlertDialogAction>
+          <AlertDialogCancel>戻る</AlertDialogCancel>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 
 import { getServerSession } from "next-auth";
-import { TbAlertCircle, TbArrowLeft, TbArrowUpRight, TbChevronRight } from "react-icons/tb";
+import { TbArrowLeft, TbArrowUpRight, TbChevronRight } from "react-icons/tb";
 
+import DeleteUserButon from "@/app/settings/delete-user-button";
 import { Logout } from "@/features/settings";
 import { authOptions } from "@/lib/auth";
 
@@ -50,7 +51,7 @@ export default async function SettingsPage() {
           <TbArrowUpRight className="h-6 w-6" />
         </a>
       </div>
-      {session && (
+      {session && session.user && (
         <>
           <h2 className="mt-8 px-4 font-bold">アカウントの操作</h2>
           <div className="mt-3 flex flex-col">
@@ -58,11 +59,7 @@ export default async function SettingsPage() {
           </div>
           <h2 className="mt-8 px-4 font-bold">取り消しができない操作</h2>
           <div className="mt-3 flex flex-col">
-            {/* TODO: モーダル表示 */}
-            <button className="flex justify-between px-4 py-3">
-              <span>退会する</span>
-              <TbAlertCircle className="h-6 w-6" />
-            </button>
+            <DeleteUserButon userId={session.user.id} />
           </div>
         </>
       )}

--- a/src/components/alert-dialog/alert-dialog.tsx
+++ b/src/components/alert-dialog/alert-dialog.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import * as React from "react";
+
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { buttonVariants } from "@/components/button/button";
+import { cn } from "@/lib/utils";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = ({ className, ...props }: AlertDialogPrimitive.AlertDialogPortalProps) => (
+  <AlertDialogPrimitive.Portal className={cn(className)} {...props} />
+);
+AlertDialogPortal.displayName = AlertDialogPrimitive.Portal.displayName;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "bg-white/30 fixed inset-0 z-50 backdrop-brightness-50 backdrop-opacity-30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed bottom-0  left-[50%] z-50 md:bottom-[30%] md:top-[50%]",
+        "translate-x-[-50%] duration-1000 md:translate-y-[-50%]",
+        "grid gap-4",
+        "w-full max-w-lg rounded-lg border bg-whitea-13 p-6 shadow-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-bottom-[0%] data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-bottom-[0%] data-[state=open]:slide-in-from-left-1/2 md:data-[state=closed]:slide-out-to-top-[48%] md:data-[state=open]:slide-in-from-top-[48%]",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description ref={ref} className={cn("text-muted-foreground text-sm", className)} {...props} />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), "h-12 rounded bg-tomato-9 text-whitea-13 md:w-24", className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-4 h-12 rounded border border-tomato-7 bg-whitea-13 text-tomato-11 md:mt-0 md:w-24",
+      className,
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,4 +15,10 @@ export const authOptions: AuthOptions = {
       clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
     }),
   ],
+  callbacks: {
+    async session({ session, token }) {
+      session.user && (session.user.id = token.sub!);
+      return session;
+    },
+  },
 };

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,4 +1,4 @@
-import NextAuth from "next-auth";
+import { type DefaultUser } from "next-auth";
 
 declare module "next-auth/adapters" {
   type JsonObject = {
@@ -10,5 +10,11 @@ declare module "next-auth/adapters" {
   interface AdapterAccount {
     type: "oauth" | "email" | "oidc";
     [key: string]: JsonValue | undefined;
+  }
+}
+
+declare module "next-auth" {
+  interface Session {
+    user?: DefaultUser & { id: string };
   }
 }


### PR DESCRIPTION
## 概要
- #127 
- ツキヤさんがIssueを立てたものですが、ダイアログは私の別画面で作成してた機能なので提案させてもらっています。

### 詳細
- 退会処理の事前準備にあたり、 SessionでログインユーザーのUser.idが取得できるようにしています
    - [この情報を参考に行いました](https://github.com/nextauthjs/next-auth/issues/7658#issuecomment-1565239992)
- ダイアログ
    - shadecnの[alert-dialog](https://ui.shadcn.com/docs/components/alert-dialog)を利用
    - ダイアログの色・デザインなどはshadecnの状態から主に下記を修正しています
         - 色：当アプリのradix-colorのtomatoに利用
         - ダイアログ出現時の画面透過度：画面が見れるようにしています
         - ダイアログの表示位置：操作性向上のためスマホサイズの画面では画面下部に表示させる

## レビュー
### スコープの整理
- 退会完了ページの作成、退会のDB周りの処理は#128 で別途対応
### レビュー観点
- ダイアログ
    - 挙動や操作性が問題ないか
    - デザインはどうか（後で直せる気がする）
- セッション周りの修正
    - ログインユーザーのUserテーブルのidがsessionから取得できているか。 

### レビュー妥協点
- ダイアログ 
    - alert-dialog.tsxのTypeScriptのエラー
        - packageが更新されてから、buttonコンポーネント含めshadcnを使ったコンポーネントにTSエラーが出るようになった
        - 上記、ぱっと解消できずのため後で対応させてもらいたい
 