### PR TITLE
[schema変更]UserテーブルのuserTypeのデフォルト値変更

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,7 +58,7 @@ model User {
   email         String?          @unique
   emailVerified DateTime?
   image         String?
-  userType      UserType         @default(chef)
+  userType      UserType         @default(general)
   profileText   String?          @db.Text
   createdAt     DateTime         @default(now())
   updatedAt     DateTime         @default(dbgenerated("CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"))


### PR DESCRIPTION
- 微修正なのでissue未作成です
- 表題の変更の背景は、新規で作成したアカウントのuserTypeがデフォルトでchefだと、トップの検索画面等でシェフ一覧にそのユーザーが表示されるためです。