### PR TITLE
人気レシピタブでお気に入り順でソートして表示

### DIFF
--- a/src/app/chef/[id]/layout.tsx
+++ b/src/app/chef/[id]/layout.tsx
@@ -1,5 +1,7 @@
+import { cache } from "react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { Metadata } from "next/types";
 
 import { jsonArrayFrom } from "kysely/helpers/mysql";
 import { getServerSession } from "next-auth";
@@ -10,6 +12,16 @@ import { Tabs } from "@/components/tabs/tabs";
 import { authOptions } from "@/lib/auth";
 import { db } from "@/lib/kysely";
 import { RecipeStatus } from "@/types/enums";
+
+const getChefById = cache(async (id: string) => {
+  return await db.selectFrom("User").selectAll().where("id", "=", id).executeTakeFirst();
+});
+
+export async function generateMetadata({ params: { id } }: { params: { id: string } }): Promise<Metadata> {
+  const chef = await getChefById(id);
+
+  return { title: chef && chef.name ? `${chef.name}/一流レシピ` : "シェフ詳細/一流レシピ" };
+}
 
 export default async function Layout({ params, children }: { params: { id: string }; children: React.ReactNode }) {
   const session = await getServerSession(authOptions);

--- a/src/app/chef/[id]/page.tsx
+++ b/src/app/chef/[id]/page.tsx
@@ -1,18 +1,4 @@
-import { cache } from "react";
-import { Metadata } from "next/types";
-
 import { getRecipeMaxCount, getRecipesWithFavoriteCount, InfiniteScrollVerticalRecipeList } from "@/features/recipes";
-import { db } from "@/lib/kysely";
-
-const getChefById = cache(async (id: string) => {
-  return await db.selectFrom("User").selectAll().where("id", "=", id).executeTakeFirst();
-});
-
-export async function generateMetadata({ params: { id } }: { params: { id: string } }): Promise<Metadata> {
-  const chef = await getChefById(id);
-
-  return { title: chef && chef.name ? `${chef.name}/一流レシピ` : "シェフ詳細/一流レシピ" };
-}
 
 export default async function Page({ params: { id } }: { params: { id: string } }) {
   const recipes = await getRecipesWithFavoriteCount({

--- a/src/app/chef/[id]/popular/page.tsx
+++ b/src/app/chef/[id]/popular/page.tsx
@@ -1,27 +1,26 @@
-import { randomUUID } from "crypto";
+import { getRecipeMaxCount, getRecipesWithFavoriteCount, InfiniteScrollVerticalRecipeList } from "@/features/recipes";
 
-import { RecipeListItemType, VerticalRecipeList } from "@/features/recipes";
-import { RecipeStatus } from "@/types/enums";
+export default async function Page({ params: { id } }: { params: { id: string } }) {
+  const recipes = await getRecipesWithFavoriteCount({
+    query: "",
+    page: undefined,
+    limit: undefined,
+    where: { userIds: [id] },
+    orderByRecipeCount: true //TODO: 無限スクロールにも渡す必要があリます
+  });
 
-export default function Page() {
-  const recipeList = Array.from({ length: 10 }).map(
-    () =>
-      ({
-        id: randomUUID(),
-        userId: randomUUID(),
-        imgSrc: "/images/recipe_02.png",
-        name: "自家燻製したノルウェーサーモンと帆立貝柱のムースのキャベツ包み蒸し 生雲丹とパセリのヴルーテ",
-        description: "中々田中ジェフシェフの超々最長ミシシッピレシピ収集",
-        servings: 3,
-        favoriteCount: 1234,
-        status: RecipeStatus.public,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      }) satisfies RecipeListItemType,
-  );
+  const recipeMaxCount = await getRecipeMaxCount({
+    query: "",
+    where: { userIds: [id] },
+  });
+
   return (
-    <div className="px-4">
-      <VerticalRecipeList recipeList={recipeList} />
-    </div>
-  );
+    <InfiniteScrollVerticalRecipeList
+      search=""
+      initialContents={recipes}
+      contentMaxCount={recipeMaxCount}
+      fetchAction={getRecipesWithFavoriteCount}
+      where={{ userIds: [id] }}
+    />
+  )
 }

--- a/src/features/recipes/lib/recipe-actions.ts
+++ b/src/features/recipes/lib/recipe-actions.ts
@@ -17,6 +17,7 @@ export async function getRecipesWithFavoriteCount({
   page = 1,
   limit = 6,
   where,
+  orderByRecipeCount = false,
 }: {
   query?: string;
   page?: number;
@@ -24,6 +25,7 @@ export async function getRecipesWithFavoriteCount({
   where?: {
     userIds: string[];
   };
+  orderByRecipeCount?: boolean;
 }) {
   const offset = (page - 1) * limit;
   const baseQuery = (() => {
@@ -53,6 +55,20 @@ export async function getRecipesWithFavoriteCount({
     prev[current["recipeId"]] = (prev[current["recipeId"]] || 0) + 1;
     return prev;
   }, {});
+
+  // TODO: 時間との兼ね合いで暫定対応です
+  if (orderByRecipeCount) {
+    return recipes
+      .flatMap((recipe) => {
+        return {
+          ...recipe,
+          favoriteCount: recipeFavoriteCounts[recipe.id] ? recipeFavoriteCounts[recipe.id] : 0,
+        };
+      })
+      .sort((a, b) => {
+        return b.favoriteCount - a.favoriteCount;
+      });
+  }
 
   return recipes.flatMap((recipe) => {
     return {


### PR DESCRIPTION
## Issue
close #151 

## 実施内容
人気レシピタブでデータをソートして表示する機能追加

## 妥協ポイント
- 無限スクロールのコンポーネントを使ってますが、スクロールしてリロードしたときに、ソートできないです。。。
- ソートのしかたとして取ってきたデータを使ってソートしてます。DBのクエリでソートして取ってくるようになってないです。。。。